### PR TITLE
Ignore `/logs/` directories when recursing

### DIFF
--- a/command.php
+++ b/command.php
@@ -16,6 +16,7 @@ class Find_Command {
 	private $ignored_paths = array(
 		'/.git/',
 		'/.svn/',
+		'/logs/',
 		'/wp-admin/',
 		'/wp-content/',
 		'/node_modules/',


### PR DESCRIPTION
Let's assume users don't install WordPress in their `/logs/` dir.