### PR TITLE
Ignore all hidden directories by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ Recursively iterates subdirectories of provided `<path>` to find and
 report WordPress installs. A WordPress install is a wp-includes directory
 with a version.php file.
 
-Avoids recursing some known paths (e.g. node_modules) to significantly
-improve performance.
+Avoids recursing some known paths (e.g. /node_modules/, hidden sys dirs)
+to significantly improve performance.
 
 Indicates depth at which the WordPress install was found, and its alias,
 if it has one.

--- a/features/find.feature
+++ b/features/find.feature
@@ -177,3 +177,22 @@ Feature: Find WordPress installs on the filesystem
       | version_path                               | alias               |
       | {TEST_DIR}/subdir1/wp-includes/version.php |                     |
       | {TEST_DIR}/subdir2/wp-includes/version.php | @test1              |
+
+  Scenario: Ignore hidden directories by default
+    Given a WP install in 'subdir1'
+    And a WP install in '.svn'
+
+    When I run `wp eval --skip-wordpress 'echo realpath( getenv( "RUN_DIR" ) );'`
+    Then save STDOUT as {TEST_DIR}
+
+    When I run `wp find {TEST_DIR} --format=count`
+    Then STDOUT should be:
+      """
+      1
+      """
+
+    When I run `wp find {TEST_DIR} --skip-ignored-paths --format=count`
+    Then STDOUT should be:
+      """
+      2
+      """

--- a/src/Find_Command.php
+++ b/src/Find_Command.php
@@ -11,10 +11,6 @@ class Find_Command {
 	 */
 	private $ignored_paths = array(
 		// System directories
-		'/.ssh/',
-		'/.git/',
-		'/.svn/',
-		'/.subversion/',
 		'/__MACOSX/',
 		// Webserver directories
 		'/cache/',
@@ -101,8 +97,8 @@ class Find_Command {
 	 * report WordPress installs. A WordPress install is a wp-includes directory
 	 * with a version.php file.
 	 *
-	 * Avoids recursing some known paths (e.g. node_modules) to significantly
-	 * improve performance.
+	 * Avoids recursing some known paths (e.g. /node_modules/, hidden sys dirs)
+	 * to significantly improve performance.
 	 *
 	 * Indicates depth at which the WordPress install was found, and its alias,
 	 * if it has one.
@@ -190,6 +186,11 @@ class Find_Command {
 		if ( ! $this->skip_ignored_paths ) {
 			// Assume base path doesn't need comparison
 			$compared_path = preg_replace( '#^' . preg_quote( $this->base_path ) . '#', '', $path );
+			// Ignore all hidden system directories
+			if ( '/.' === substr( $compared_path, 0, 2 ) ) {
+				$this->log( "Matched ignored path. Skipping recursion into '{$path}'" );
+				return;
+			}
 			foreach( $this->ignored_paths as $ignored_path ) {
 				if ( false !== stripos( $compared_path, $ignored_path ) ) {
 					$this->log( "Matched ignored path. Skipping recursion into '{$path}'" );


### PR DESCRIPTION
It's safe to assume WordPress isn't installed in one