### PR TITLE
Add `/coockies/` to ignored paths

### DIFF
--- a/src/Find_Command.php
+++ b/src/Find_Command.php
@@ -42,6 +42,8 @@ class Find_Command {
 		'/bower_components/',
 		'/vendor/',
 		'/svn/',
+		// Directory for a common script kiddie hack
+		'/coockies/',
 		// Already in a WordPress install
 		'/wp-admin/',
 		'/wp-content/',


### PR DESCRIPTION
It's a directory used by a common hack, which takes forever to recurse

See https://www.sitepoint.com/community/t/what-is-mean-by-coockies/21654/4