### PR TITLE
Fix variable name mismatch in catch clause

### DIFF
--- a/src/Find_Command.php
+++ b/src/Find_Command.php
@@ -284,7 +284,7 @@ class Find_Command {
 						}
 						$this->found_wp[ $version_path ][ $constant ] = $value;
 					}
-				} catch ( \Exception $e ) {
+				} catch ( Exception $exception ) {
 					$this->log( "Could not process the 'wp-config.php' transformation: " . $e->getMessage() );
 				}
 			}

--- a/src/Find_Command.php
+++ b/src/Find_Command.php
@@ -285,7 +285,7 @@ class Find_Command {
 						$this->found_wp[ $version_path ][ $constant ] = $value;
 					}
 				} catch ( \Exception $e ) {
-					$this->log( "Could not process the 'wp-config.php' transformation: " . $exception->getMessage() );
+					$this->log( "Could not process the 'wp-config.php' transformation: " . $e->getMessage() );
 				}
 			}
 			$this->log( "Found WordPress installation at '{$version_path}'" );

--- a/src/Find_Command.php
+++ b/src/Find_Command.php
@@ -285,7 +285,7 @@ class Find_Command {
 						$this->found_wp[ $version_path ][ $constant ] = $value;
 					}
 				} catch ( Exception $exception ) {
-					$this->log( "Could not process the 'wp-config.php' transformation: " . $e->getMessage() );
+					$this->log( "Could not process the 'wp-config.php' transformation: " . $exception->getMessage() );
 				}
 			}
 			$this->log( "Found WordPress installation at '{$version_path}'" );


### PR DESCRIPTION
This was crashing the plugin for some specific WordPress instances. Fixing the exception variable name resolves the problem for me.