### PR TITLE
Replace empty namespace autoloader with classmap

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,9 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "autoload": {
-        "psr-4": {"": "src/"},
+        "classmap": [
+            "src/"
+        ],
         "files": [ "find-command.php" ]
     },
     "require": {


### PR DESCRIPTION
This fixes the issue described here: https://github.com/wp-cli/wp-cli/issues/5731
