### PR TITLE
Require wp-cli/wp-cli v2.13

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     },
     "require": {
         "php": ">=7.2.24",
-        "wp-cli/wp-cli": "^2.12"
+        "wp-cli/wp-cli": "^2.13"
     },
     "require-dev": {
         "wp-cli/wp-cli-tests": "^5.0.0"

--- a/features/find.feature
+++ b/features/find.feature
@@ -215,7 +215,7 @@ Feature: Find WordPress installs on the filesystem
       2
       """
 
-    When I run `wp find {TEST_DIR} --include_ignored_paths="/subdir1/,/apple/" --format=count`
+    When I run `wp find {TEST_DIR} "--include_ignored_paths=/subdir1/,/apple/" --format=count`
     Then STDOUT should be:
       """
       1

--- a/features/find.feature
+++ b/features/find.feature
@@ -70,7 +70,7 @@ Feature: Find WordPress installs on the filesystem
 
   Scenario: Use --max_depth=<depth> to specify max recursion depth
     Given a WP install in 'subdir1'
-    And I run `mkdir -p sub/sub`
+    And an empty sub/sub directory
     And a WP install in 'sub/subdir2'
     And a WP install in 'sub/sub/subdir3'
 
@@ -169,8 +169,11 @@ Feature: Find WordPress installs on the filesystem
     When I run `wp eval --skip-wordpress "echo WP_CLI\Path::normalize( realpath( getenv( 'RUN_DIR' ) ) );"`
     Then save STDOUT as {TEST_DIR}
 
-    When I run `echo "@test1:\n  path: {TEST_DIR}/subdir2" > wp-cli.yml`
-    Then the return code should be 0
+    Given a wp-cli.yml file:
+      """
+      @test1:
+        path: {TEST_DIR}/subdir2
+      """
 
     When I run `wp find {TEST_DIR} --fields=version_path,alias`
     Then STDOUT should be a table containing rows:
@@ -181,7 +184,7 @@ Feature: Find WordPress installs on the filesystem
   Scenario: Ignore hidden directories by default
     Given a WP install in 'subdir1'
     And a WP install in '.svn'
-    And I run `mkdir -p subdir2/.svn`
+    And an empty subdir2/.svn directory
     And a WP install in 'subdir2/.svn/wp-install'
 
     When I run `wp eval --skip-wordpress "echo WP_CLI\Path::normalize( realpath( getenv( 'RUN_DIR' ) ) );"`
@@ -212,7 +215,7 @@ Feature: Find WordPress installs on the filesystem
       2
       """
 
-    When I run `wp find {TEST_DIR} --include_ignored_paths='/subdir1/,/apple/' --format=count`
+    When I run `wp find {TEST_DIR} --include_ignored_paths=/subdir1/,/apple/ --format=count`
     Then STDOUT should be:
       """
       1

--- a/features/find.feature
+++ b/features/find.feature
@@ -215,7 +215,7 @@ Feature: Find WordPress installs on the filesystem
       2
       """
 
-    When I run `wp find {TEST_DIR} --include_ignored_paths=/subdir1/,/apple/ --format=count`
+    When I run `wp find {TEST_DIR} --include_ignored_paths="/subdir1/,/apple/" --format=count`
     Then STDOUT should be:
       """
       1

--- a/features/find.feature
+++ b/features/find.feature
@@ -4,7 +4,7 @@ Feature: Find WordPress installs on the filesystem
     Given a WP install in 'subdir1'
     And a WP install in 'subdir2'
 
-    When I run `wp eval --skip-wordpress 'echo realpath( getenv( "RUN_DIR" ) );'`
+    When I run `wp eval --skip-wordpress "echo WP_CLI\Path::normalize( realpath( getenv( 'RUN_DIR' ) ) );"`
     Then save STDOUT as {TEST_DIR}
 
     When I run `wp find {TEST_DIR} --field=version_path | sort`
@@ -35,7 +35,7 @@ Feature: Find WordPress installs on the filesystem
     And a WP install in 'cache'
     And a WP install in 'tmp'
 
-    When I run `wp eval --skip-wordpress 'echo realpath( getenv( "RUN_DIR" ) );'`
+    When I run `wp eval --skip-wordpress "echo WP_CLI\Path::normalize( realpath( getenv( 'RUN_DIR' ) ) );"`
     Then save STDOUT as {TEST_DIR}
 
     When I run `wp find {TEST_DIR} --field=version_path --verbose`
@@ -74,7 +74,7 @@ Feature: Find WordPress installs on the filesystem
     And a WP install in 'sub/subdir2'
     And a WP install in 'sub/sub/subdir3'
 
-    When I run `wp eval --skip-wordpress 'echo realpath( getenv( "RUN_DIR" ) );'`
+    When I run `wp eval --skip-wordpress "echo WP_CLI\Path::normalize( realpath( getenv( 'RUN_DIR' ) ) );"`
     Then save STDOUT as {TEST_DIR}
 
     When I run `wp find {TEST_DIR} --verbose`
@@ -166,7 +166,7 @@ Feature: Find WordPress installs on the filesystem
     Given a WP install in 'subdir1'
     And a WP install in 'subdir2'
 
-    When I run `wp eval --skip-wordpress 'echo realpath( getenv( "RUN_DIR" ) );'`
+    When I run `wp eval --skip-wordpress "echo WP_CLI\Path::normalize( realpath( getenv( 'RUN_DIR' ) ) );"`
     Then save STDOUT as {TEST_DIR}
 
     When I run `echo "@test1:\n  path: {TEST_DIR}/subdir2" > wp-cli.yml`
@@ -184,7 +184,7 @@ Feature: Find WordPress installs on the filesystem
     And I run `mkdir -p subdir2/.svn`
     And a WP install in 'subdir2/.svn/wp-install'
 
-    When I run `wp eval --skip-wordpress 'echo realpath( getenv( "RUN_DIR" ) );'`
+    When I run `wp eval --skip-wordpress "echo WP_CLI\Path::normalize( realpath( getenv( 'RUN_DIR' ) ) );"`
     Then save STDOUT as {TEST_DIR}
 
     When I run `wp find {TEST_DIR} --format=count`
@@ -203,7 +203,7 @@ Feature: Find WordPress installs on the filesystem
     Given a WP install in 'subdir1'
     And a WP install in 'subdir2'
 
-    When I run `wp eval --skip-wordpress 'echo realpath( getenv( "RUN_DIR" ) );'`
+    When I run `wp eval --skip-wordpress "echo WP_CLI\Path::normalize( realpath( getenv( 'RUN_DIR' ) ) );"`
     Then save STDOUT as {TEST_DIR}
 
     When I run `wp find {TEST_DIR} --format=count`
@@ -224,7 +224,7 @@ Feature: Find WordPress installs on the filesystem
     And a WP install in 'logs'
     And a WP install in 'js'
 
-    When I run `wp eval --skip-wordpress 'echo realpath( getenv( "RUN_DIR" ) );'`
+    When I run `wp eval --skip-wordpress "echo WP_CLI\Path::normalize( realpath( getenv( 'RUN_DIR' ) ) );"`
     Then save STDOUT as {TEST_DIR}
 
     When I run `wp find {TEST_DIR} --field=version_path --verbose`

--- a/features/find.feature
+++ b/features/find.feature
@@ -209,11 +209,11 @@ Feature: Find WordPress installs on the filesystem
     When I run `wp eval --skip-wordpress "echo WP_CLI\Path::normalize( realpath( getenv( 'RUN_DIR' ) ) );"`
     Then save STDOUT as {TEST_DIR}
 
-    When I run `wp find {TEST_DIR} --format=count`
-    Then STDOUT should be:
-      """
-      2
-      """
+#    When I run `wp find {TEST_DIR} --format=count`
+#    Then STDOUT should be:
+#      """
+#      2
+#      """
 
     When I run `wp find {TEST_DIR} "--include_ignored_paths=/subdir1/,/apple/" --format=count`
     Then STDOUT should be:

--- a/features/find.feature
+++ b/features/find.feature
@@ -209,13 +209,13 @@ Feature: Find WordPress installs on the filesystem
     When I run `wp eval --skip-wordpress "echo WP_CLI\Path::normalize( realpath( getenv( 'RUN_DIR' ) ) );"`
     Then save STDOUT as {TEST_DIR}
 
-#    When I run `wp find {TEST_DIR} --format=count`
-#    Then STDOUT should be:
-#      """
-#      2
-#      """
+    When I run `wp find {TEST_DIR} --format=count`
+    Then STDOUT should be:
+      """
+      2
+      """
 
-    When I run `wp find {TEST_DIR} "--include_ignored_paths=/subdir1/,/apple/" --format=count`
+    When I run `wp find {TEST_DIR} "--include_ignored_paths=subdir1,apple" --format=count`
     Then STDOUT should be:
       """
       1

--- a/src/Find_Command.php
+++ b/src/Find_Command.php
@@ -254,6 +254,10 @@ class Find_Command {
 		if ( ! $this->skip_ignored_paths ) {
 			// Assume base path doesn't need comparison
 			$compared_path = (string) preg_replace( '#^' . preg_quote( $this->base_path, '#' ) . '#i', '', $path );
+			WP_CLI::log( "DEBUG: base_path='{$this->base_path}'" );
+			WP_CLI::log( "DEBUG: path='{$path}'" );
+			WP_CLI::log( "DEBUG: compared_path='{$compared_path}'" );
+			WP_CLI::log( "DEBUG: ignored_paths='" . implode( ',', $this->ignored_paths ) . "'" );
 			// Ignore all hidden system directories
 			$bits        = explode( '/', trim( $compared_path, '/' ) );
 			$current_dir = array_pop( $bits );

--- a/src/Find_Command.php
+++ b/src/Find_Command.php
@@ -198,8 +198,13 @@ class Find_Command {
 		$this->base_path          = Path::normalize( $base_path );
 		$this->skip_ignored_paths = Utils\get_flag_value( $assoc_args, 'skip-ignored-paths' );
 		if ( ! empty( $assoc_args['include_ignored_paths'] ) ) {
-			$included_paths      = explode( ',', $assoc_args['include_ignored_paths'] );
-			$included_paths      = array_map( [ 'WP_CLI\Path', 'normalize' ], $included_paths );
+			$included_paths      = explode( ',', trim( $assoc_args['include_ignored_paths'], "\"' " ) );
+			$included_paths      = array_map(
+				static function ( $path ) {
+					return Path::normalize( trim( $path, "\"' " ) );
+				},
+				$included_paths
+			);
 			$this->ignored_paths = array_merge( $this->ignored_paths, $included_paths );
 		}
 		$this->max_depth = Utils\get_flag_value( $assoc_args, 'max_depth', false );
@@ -215,7 +220,13 @@ class Find_Command {
 
 		$fields = [ 'version_path', 'version', 'depth', 'alias' ];
 		if ( ! empty( $assoc_args['fields'] ) ) {
-			$fields = explode( ',', $assoc_args['fields'] );
+			$fields = explode( ',', trim( $assoc_args['fields'], "\"' " ) );
+			$fields = array_map(
+				static function ( $field ) {
+					return trim( $field, "\"' " );
+				},
+				$fields
+			);
 		}
 
 		$this->start_time = microtime( true );

--- a/src/Find_Command.php
+++ b/src/Find_Command.php
@@ -254,12 +254,9 @@ class Find_Command {
 		if ( ! $this->skip_ignored_paths ) {
 			// Assume base path doesn't need comparison
 			$compared_path = (string) preg_replace( '#^' . preg_quote( $this->base_path, '#' ) . '#i', '', $path );
-			WP_CLI::log( "DEBUG: base_path='{$this->base_path}'" );
-			WP_CLI::log( "DEBUG: path='{$path}'" );
-			WP_CLI::log( "DEBUG: compared_path='{$compared_path}'" );
-			WP_CLI::log( "DEBUG: ignored_paths='" . implode( ',', $this->ignored_paths ) . "'" );
 			// Ignore all hidden system directories
-			$bits        = explode( '/', trim( $compared_path, '/' ) );
+			$bits = explode( '/', trim( $compared_path, '/' ) );
+
 			$current_dir = array_pop( $bits );
 			if ( $current_dir && '.' === $current_dir[0] ) {
 				$this->log( "Matched ignored path. Skipping recursion into '{$path}'" );

--- a/src/Find_Command.php
+++ b/src/Find_Command.php
@@ -2,6 +2,7 @@
 
 use WP_CLI\Utils;
 use WP_CLI\Formatter;
+use WP_CLI\Path;
 
 class Find_Command {
 
@@ -189,14 +190,17 @@ class Find_Command {
 	 * @when before_wp_load
 	 */
 	public function __invoke( $args, $assoc_args ) {
-		list( $path )    = $args;
-		$this->base_path = (string) realpath( $path );
-		if ( ! $this->base_path ) {
+		list( $path ) = $args;
+		$base_path    = (string) realpath( $path );
+		if ( ! $base_path ) {
 			WP_CLI::error( 'Invalid path specified.' );
 		}
+		$this->base_path          = Path::normalize( $base_path );
 		$this->skip_ignored_paths = Utils\get_flag_value( $assoc_args, 'skip-ignored-paths' );
 		if ( ! empty( $assoc_args['include_ignored_paths'] ) ) {
-			$this->ignored_paths = array_merge( $this->ignored_paths, explode( ',', $assoc_args['include_ignored_paths'] ) );
+			$included_paths      = explode( ',', $assoc_args['include_ignored_paths'] );
+			$included_paths      = array_map( [ 'WP_CLI\Path', 'normalize' ], $included_paths );
+			$this->ignored_paths = array_merge( $this->ignored_paths, $included_paths );
 		}
 		$this->max_depth = Utils\get_flag_value( $assoc_args, 'max_depth', false );
 		$this->verbose   = Utils\get_flag_value( $assoc_args, 'verbose' );
@@ -206,7 +210,7 @@ class Find_Command {
 			if ( empty( $target['path'] ) ) {
 				continue;
 			}
-			$this->resolved_aliases[ rtrim( $target['path'], '/' ) ] = $alias;
+			$this->resolved_aliases[ rtrim( Path::normalize( $target['path'] ), '/' ) ] = $alias;
 		}
 
 		$fields = [ 'version_path', 'version', 'depth', 'alias' ];
@@ -228,6 +232,8 @@ class Find_Command {
 		if ( is_link( $path ) ) {
 			return;
 		}
+
+		$path = Path::normalize( $path );
 
 		// Provide consistent trailing slashes to all paths
 		$path = rtrim( $path, '/' ) . '/';
@@ -254,7 +260,7 @@ class Find_Command {
 
 		// This looks like a wp-includes directory, so check if it has a
 		// version.php file.
-		if ( DIRECTORY_SEPARATOR . 'wp-includes/' === substr( $path, -13 )
+		if ( '/wp-includes/' === substr( $path, -13 )
 			&& file_exists( $path . 'version.php' ) ) {
 			$version_path = $path . 'version.php';
 			$wp_path      = substr( $path, 0, -13 );
@@ -346,7 +352,7 @@ class Find_Command {
 		}
 
 		if ( $path ) {
-			$path = realpath( $path );
+			$path = Path::normalize( (string) realpath( $path ) );
 		}
 		return $path;
 	}

--- a/src/Find_Command.php
+++ b/src/Find_Command.php
@@ -258,7 +258,7 @@ class Find_Command {
 			&& file_exists( $path . 'version.php' ) ) {
 			$version_path = $path . 'version.php';
 			$wp_path      = substr( $path, 0, -13 );
-			$alias        = isset( $this->resolved_aliases[ $wp_path ] ) ? $this->resolved_aliases[ $wp_path ] : '';
+			$alias        = isset( $this->resolved_aliases[ $wp_path ] ) ? '@' . $this->resolved_aliases[ $wp_path ] : '';
 			$wp_path      = rtrim( $wp_path, '/' ) . '/';
 
 			$this->found_wp[ $version_path ] = [

--- a/src/Find_Command.php
+++ b/src/Find_Command.php
@@ -253,7 +253,7 @@ class Find_Command {
 		// Don't recurse directories that probably don't have a WordPress installation.
 		if ( ! $this->skip_ignored_paths ) {
 			// Assume base path doesn't need comparison
-			$compared_path = (string) preg_replace( '#^' . preg_quote( $this->base_path, '#' ) . '#i', '', $path );
+			$compared_path = (string) preg_replace( '#^' . preg_quote( $this->base_path, '#' ) . '#' . ( '\\' === DIRECTORY_SEPARATOR ? 'i' : '' ), '', $path );
 			// Ignore all hidden system directories
 			$bits = explode( '/', trim( $compared_path, '/' ) );
 

--- a/src/Find_Command.php
+++ b/src/Find_Command.php
@@ -201,7 +201,8 @@ class Find_Command {
 			$included_paths      = explode( ',', trim( $assoc_args['include_ignored_paths'], "\"' " ) );
 			$included_paths      = array_map(
 				static function ( $path ) {
-					return Path::normalize( trim( $path, "\"' " ) );
+					$path = Path::normalize( trim( $path, "\"' " ) );
+					return ltrim( rtrim( $path, '/' ) . '/', '/' );
 				},
 				$included_paths
 			);
@@ -252,7 +253,7 @@ class Find_Command {
 		// Don't recurse directories that probably don't have a WordPress installation.
 		if ( ! $this->skip_ignored_paths ) {
 			// Assume base path doesn't need comparison
-			$compared_path = (string) preg_replace( '#^' . preg_quote( $this->base_path, '#' ) . '#', '', $path );
+			$compared_path = (string) preg_replace( '#^' . preg_quote( $this->base_path, '#' ) . '#i', '', $path );
 			// Ignore all hidden system directories
 			$bits        = explode( '/', trim( $compared_path, '/' ) );
 			$current_dir = array_pop( $bits );


### PR DESCRIPTION
This way a newer version of wp-cli/wp-cli-tests will be required with better Windows compatibility.

Also fixes Windows tests.
